### PR TITLE
Guard optional Puppeteer calls from undefined methods

### DIFF
--- a/JS/master.js
+++ b/JS/master.js
@@ -92,7 +92,7 @@ async function clickOptionByText(ctx, text, timeout = 30000) {
     const el = await handle.asElement();
     if (el) {
       try {
-        await el.scrollIntoViewIfNeeded?.().catch(() => { });
+        await el.scrollIntoViewIfNeeded?.().catch?.(() => { });
         await el.click({ delay: 10 });
         return true;
       } catch {
@@ -120,7 +120,7 @@ async function typeAndSelect(ctx, page, inputSelector, query, optionText) {
   await clearInput(ctx, inputSelector);
   // Ensure focus, then type slowly to trigger app filters
   await ctx.click(inputSelector, { delay: 10 }).catch(() => { });
-  await ctx.focus?.(inputSelector).catch(() => { });
+  await ctx.focus?.(inputSelector).catch?.(() => { });
   // If ctx is a Frame, use page.keyboard (the focused element is within the frame)
   await page.keyboard.type(query, { delay: 40 });
 

--- a/JS/master_nu.js
+++ b/JS/master_nu.js
@@ -103,7 +103,7 @@ async function clickOptionByText(ctx, text, timeout = 30000) {
     const el = await handle.asElement();
     if (el) {
       try {
-        await el.scrollIntoViewIfNeeded?.().catch(() => { });
+        await el.scrollIntoViewIfNeeded?.().catch?.(() => { });
         await el.click({ delay: 10 });
         return true;
       } catch {
@@ -131,7 +131,7 @@ async function typeAndSelect(ctx, page, inputSelector, query, optionText) {
   await clearInput(ctx, inputSelector);
   // Ensure focus, then type slowly to trigger app filters
   await ctx.click(inputSelector, { delay: 10 }).catch(() => { });
-  await ctx.focus?.(inputSelector).catch(() => { });
+  await ctx.focus?.(inputSelector).catch?.(() => { });
   // If ctx is a Frame, use page.keyboard (the focused element is within the frame)
   await page.keyboard.type(query, { delay: 40 });
 


### PR DESCRIPTION
## Summary
- Prevent TypeErrors when `scrollIntoViewIfNeeded` or `focus` are unavailable by safely chaining `.catch`
- Apply fix across both Mastercard scraping scripts

## Testing
- `node --check JS/master.js`
- `node --check JS/master_nu.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7d89d3508330997469f3810acd94